### PR TITLE
Fix markdown link formatting in "Editor and IDE Plugins" section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@
 
 ## Editor and IDE Plugins
 
-See (Editor and tool support)[https://github.com/purescript/purescript/wiki/Editor-and-tool-support]
+See [Editor and tool support](https://github.com/purescript/purescript/wiki/Editor-and-tool-support)
 
 ## Community
 


### PR DESCRIPTION
Hi there,

I noticed a small markdown syntax issue with the `Editor and IDE Plugins` section. This PR just fixes the section to match what I think was the intended output.

---

_Current version:_
![screen shot 2016-06-26 at 3 34 20 pm](https://cloud.githubusercontent.com/assets/3409214/16364405/246c673a-3bb4-11e6-8924-674d8ba648b6.png)

---

_My updated version:_
![screen shot 2016-06-26 at 3 34 03 pm](https://cloud.githubusercontent.com/assets/3409214/16364417/65bf73da-3bb4-11e6-80b8-ecbc4c5fe2ef.png)

---
##### Thanks for creating the guide!
