### PR TITLE
Add `react-basic-hooks`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ React-based:
 - [purescript-react](https://github.com/purescript-contrib/purescript-react) - React bindings for PureScript
 - [purescript-react-simple](https://github.com/joneshf/purescript-react-simple) - A simplified wrapper around react.
 - [purescript-react-basic](https://github.com/lumihq/purescript-react-basic) - An opinionated set of bindings to the React library, optimizing for the most basic use cases.
+- [purescript-react-basic-hooks](https://github.com/spicydonuts/purescript-react-basic-hooks) - An alternative way to define React components using React's "hooks" APIs. Compatible with `purescript-react-basic`.
 - [purescript-pux](https://github.com/alexmingoia/purescript-pux) - Build type-safe web apps with PureScript.
 - [purescript-spork](https://github.com/natefaubion/purescript-spork) - Elm-like for PureScript.
 - [purescript-concur](https://github.com/ajnsit/purescript-concur) - Concur UI framework. React backend, but can use others.


### PR DESCRIPTION
It might also make sense to remove `react-simple` from this list. I don't think it's compiled for a few years.