### PR TITLE
Remove blockquote

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # awesome-purescript [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-> A curated list of delightful libraries, tools and other shiny things for PureScript.
+A curated list of delightful libraries, tools and other shiny things for PureScript.
 
 ## Build Tooling
 


### PR DESCRIPTION
`>` denotes a `<blockquote>` in Markdown and is rendered as such.

> The blockquote element represents a section that is quoted from another source.

— W3C HTML spec, https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element

This block was not not quoting a source. I’m not sure if this was just a oversight.