### PR TITLE
IRC: Freenode → Libera.Chat

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,7 +125,7 @@ See [Editor and tool support](https://github.com/purescript/purescript/wiki/Edit
 ## Community
 
 - [`/r/purescript` subreddit](http://www.reddit.com/r/purescript)
-- [`#purescript` on Freenode](http://webchat.freenode.net/?channels=purescript)
+- `#purescript` on Libera.Chat ([web](https://web.libera.chat/?channels=#purescript), [lightweight web](https://web.libera.chat/gamja/?channels=%23purescript))
 - [Stack Overflow `purescript` tag](http://stackoverflow.com/questions/tagged/purescript)
 - [Google Group](https://groups.google.com/forum/#!forum/purescript)
 


### PR DESCRIPTION
Most of the open source community moved away from Freenode after the take over. Libera.Chat [links two webchat options](https://libera.chat/guides/webchat) on their site, so I linked both.